### PR TITLE
Fix for merging configs

### DIFF
--- a/lib/mix/lib/releases/config/providers/elixir.ex
+++ b/lib/mix/lib/releases/config/providers/elixir.ex
@@ -63,7 +63,7 @@ defmodule Mix.Releases.Config.Providers.Elixir do
       merged_app_config =
         app
         |> Application.get_all_env()
-        |> Mix.Config.merge(app_config)
+        |> Mix.Config.merge([{app, app_config}])
       {app, merged_app_config}
     end)
   end


### PR DESCRIPTION
Stack trace:

```
=INFO REPORT==== 9-Aug-2018::18:45:26 ===
    application: mix
    exited: stopped
    type: temporary
no function clause matching in Keyword.merge/3
    (elixir) lib/keyword.ex:726: Keyword.merge("FOO", "FOO", #Function<6.105162710/3 in Mix.Config.merge/2>)
    (elixir) lib/keyword.ex:739: Keyword.do_merge/6
    (distillery) lib/mix/lib/releases/config/providers/elixir.ex:66: anonymous fn/1 in Mix.Releases.Config.Providers.Elixir.merge_config/1
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (distillery) lib/mix/lib/releases/config/providers/elixir.ex:46: Mix.Releases.Config.Providers.Elixir.init/1
    (distillery) lib/mix/lib/releases/config/provider.ex:97: anonymous fn/2 in Mix.Releases.Config.Provider.init/1
    (elixir) lib/enum.ex:1899: Enum."-reduce/3-lists^foldl/2-0-"/3
    (distillery) lib/mix/lib/releases/config/provider.ex:88: Mix.Releases.Config.Provider.init/1
```

Example config:

```
config :app,
  key1: "FOO"
```

The correct way of merging 2 configs: https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/config.ex#L106

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ x] New functions have typespecs, changed functions were updated
- [ x] Same for documentation, including moduledocs
- [ x] Tests were added or updated to cover changes
- [ x] Commits were squashed into a single coherent commit
